### PR TITLE
Add intro sections in docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,12 @@
+# Documentation de l'API
+
+Ce document décrit la future interface de programmation (API) du projet **Entreprise Organiser**. Vous y trouverez une vue d'ensemble des points d'entrée, des paramètres attendus et des conventions de réponse. Il servira de référence pour les développeurs souhaitant intégrer ou étendre l'application.
+
+Les sections détailleront notamment :
+
+- L'authentification et la gestion des tokens
+- Les principaux endpoints REST
+- Les modèles de données utilisés
+- Les codes d'erreur standard
+
+Ce fichier est encore en cours de rédaction et sera enrichi au fur et à mesure du développement.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,0 +1,11 @@
+# Architecture Générale
+
+Ce fichier présente l'architecture globale du projet **Entreprise Organiser**. Il sert de point d'entrée pour comprendre la répartition des différentes briques applicatives et la manière dont elles interagissent.
+
+La plateforme est organisée selon une structure classique :
+
+- Un serveur backend (Node.js/NestJS) responsable de l'API et de la logique métier
+- Une application frontend (React) servie par Nginx
+- Des services complémentaires comme PostgreSQL pour la base de données et Redis pour le cache
+
+La communication se fait principalement via HTTP/REST, mais d'autres protocoles pourront être utilisés à l'avenir. Ce document sera complété avec des diagrammes et des explications détaillées au fur et à mesure de la conception.

--- a/docs/Guidelines.md
+++ b/docs/Guidelines.md
@@ -1,0 +1,12 @@
+# Bonnes Pratiques de Développement
+
+Ce document rassemble les règles et recommandations à suivre pour contribuer efficacement au projet **Entreprise Organiser**. Il permet d'assurer une cohérence du code et de faciliter la collaboration entre les développeurs.
+
+Quelques points clés :
+
+- Respecter la structure du dépôt et l'organisation en packages
+- Écrire des commits clairs avec des messages explicites
+- Maintenir une couverture de tests suffisante
+- Utiliser un style de code homogène (ESLint et Prettier)
+
+Au fil du temps, ce guide sera enrichi d'exemples précis et de consignes supplémentaires pour chaque partie de l'application.

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -1,0 +1,12 @@
+# Procédure d'Installation
+
+Ce guide explique comment mettre en place un environnement de développement opérationnel pour **Entreprise Organiser**. Il est destiné aux nouveaux contributeurs ainsi qu'à toute personne souhaitant tester l'application en local.
+
+Étapes principales :
+
+1. Cloner ce dépôt Git
+2. Installer les dépendances Node.js via `pnpm install`
+3. Configurer les variables d'environnement (voir `.env.example`)
+4. Lancer les services backend et frontend avec `run-servers.sh`
+
+Des sections détaillées seront ajoutées pour la configuration de la base de données et l'utilisation de Docker. N'hésitez pas à proposer des améliorations !


### PR DESCRIPTION
## Summary
- provide a short overview for API documentation
- describe global architecture
- note development guidelines
- outline basic setup steps

## Testing
- `npm test` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d9dbbccc8332ba89eae2dfce0690