### PR TITLE
Add calculateProgress test for unknown status

### DIFF
--- a/tests/frontend/services.test.jsx
+++ b/tests/frontend/services.test.jsx
@@ -37,11 +37,12 @@ describe('Services Frontend', () => {
       expect(formatted).toMatch(/15\/03\/2024/);
     });
 
-    test('calculerProgression calcule correctement le pourcentage', () => {
-      expect(affairesService.calculerProgression('EN_COURS')).toBe(50);
-      expect(affairesService.calculerProgression('TERMINE')).toBe(100);
-      expect(affairesService.calculerProgression('EN_ATTENTE')).toBe(25);
-      expect(affairesService.calculerProgression('ANNULE')).toBe(0);
+    test('calculateProgress calcule correctement le pourcentage', () => {
+      expect(affairesService.calculateProgress({ statut: 'EN_COURS' })).toBe(50);
+      expect(affairesService.calculateProgress({ statut: 'TERMINE' })).toBe(100);
+      expect(affairesService.calculateProgress({ statut: 'EN_ATTENTE' })).toBe(25);
+      expect(affairesService.calculateProgress({ statut: 'ANNULE' })).toBe(0);
+      expect(affairesService.calculateProgress({ statut: 'INCONNU' })).toBe(0);
     });
 
     test('getAffaires fait un appel API correct', async () => {


### PR DESCRIPTION
## Summary
- check `calculateProgress` with an unknown status in frontend tests
- update progress test to call the correct service method

## Testing
- `npm test --silent` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d9dfc008833293b009a6bcf1292b