### PR TITLE
Fix calculateProgress test

### DIFF
--- a/tests/frontend/services.test.jsx
+++ b/tests/frontend/services.test.jsx
@@ -38,10 +38,10 @@ describe('Services Frontend', () => {
     });
 
     test('calculerProgression calcule correctement le pourcentage', () => {
-      expect(affairesService.calculerProgression('EN_COURS')).toBe(50);
-      expect(affairesService.calculerProgression('TERMINE')).toBe(100);
-      expect(affairesService.calculerProgression('EN_ATTENTE')).toBe(25);
-      expect(affairesService.calculerProgression('ANNULE')).toBe(0);
+      expect(affairesService.calculateProgress({ statut: 'EN_COURS' })).toBe(50);
+      expect(affairesService.calculateProgress({ statut: 'TERMINE' })).toBe(100);
+      expect(affairesService.calculateProgress({ statut: 'EN_ATTENTE' })).toBe(25);
+      expect(affairesService.calculateProgress({ statut: 'ANNULE' })).toBe(0);
     });
 
     test('getAffaires fait un appel API correct', async () => {


### PR DESCRIPTION
## Summary
- update frontend service test to use `calculateProgress` and pass objects

## Testing
- `npm test` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846db4eb514833296b8ef37c0ae7ad6