### PR TITLE
Use MONGO_URI and provide env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Server configuration
+PORT=5001
+HOST=localhost
+NODE_ENV=development
+
+# Database
+MONGO_URI=mongodb://localhost:27017/entreprise-organiser
+
+# JWT
+JWT_SECRET=entreprise_organiser_secret_key_2025
+JWT_EXPIRE=1d
+
+# CORS
+CORS_ORIGIN=http://localhost:5173
+FRONTEND_URL=http://localhost:5173
+
+# Email configuration
+EMAIL_FROM="Entreprise Organiser" <noreply@entreprise-organiser.com>
+EMAIL_HOST=smtp.ethereal.email
+EMAIL_PORT=587
+EMAIL_SECURE=false
+EMAIL_USER=
+EMAIL_PASS=
+
+# Frontend
+VITE_API_URL=http://localhost:5001/api

--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -6,7 +6,7 @@ const mongoose = require('mongoose');
 const connectDB = async () => {
   try {
     const conn = await mongoose.connect(
-      process.env.MONGODB_URI || 'mongodb://localhost:27017/entreprise-organiser',
+      process.env.MONGO_URI || 'mongodb://localhost:27017/entreprise-organiser',
       {
         useNewUrlParser: true,
         useUnifiedTopology: true,


### PR DESCRIPTION
## Summary
- use `process.env.MONGO_URI` for Mongo connection
- add `.env.example` with common configuration

## Testing
- `npm test` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e075e4b48332ae2d940f662c9916