### PR TITLE
Implémentation refresh token et 2FA

### DIFF
--- a/backend/createEnv.js
+++ b/backend/createEnv.js
@@ -7,6 +7,12 @@ DATABASE_URL="postgresql://postgres:password@localhost:5432/entreprise_organiser
 # JWT Secret
 JWT_SECRET="votre_secret_jwt_super_securise"
 
+# Refresh Token Secret
+REFRESH_TOKEN_SECRET="votre_refresh_token_secret"
+
+# Encryption Secret
+ENCRYPTION_SECRET="votre_encryption_secret"
+
 # Environnement
 NODE_ENV="development"
 `;

--- a/backend/package.json
+++ b/backend/package.json
@@ -46,6 +46,8 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "prisma": "^6.8.2",
+    "speakeasy": "^2.0.0",
+    "express-rate-limit": "^6.7.0",
     "typescript": "^5.8.3"
   },
   "devDependencies": {

--- a/backend/src/config/config.js
+++ b/backend/src/config/config.js
@@ -24,6 +24,16 @@ const config = {
     secret: process.env.JWT_SECRET || 'entreprise_organiser_secret_key_2025',
     expiresIn: process.env.JWT_EXPIRE || '1d'
   },
+
+  // Refresh Token
+  refreshToken: {
+    secret: process.env.REFRESH_TOKEN_SECRET || 'entreprise_organiser_refresh_secret',
+    expiresIn: process.env.REFRESH_TOKEN_EXPIRE || '7d'
+  },
+
+  encryption: {
+    secret: process.env.ENCRYPTION_SECRET || 'entreprise_organiser_encrypt_secret'
+  },
   
   // Cors
   cors: {

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -140,7 +140,7 @@ exports.login = async (req, res) => {
       }
       const verified = speakeasy.totp.verify({
         secret: decrypt(user.twoFactorSecret),
-        encoding: 'ascii',
+        encoding: 'base32',
         token: twoFactorToken
       });
       if (!verified) {
@@ -500,11 +500,15 @@ exports.enableTwoFactor = async (req, res) => {
     }
 
     const secret = speakeasy.generateSecret();
-    user.twoFactorSecret = encrypt(secret.ascii);
+    // Stocker le secret chiffré en base32 pour une compatibilité maximale
+    user.twoFactorSecret = encrypt(secret.base32);
     user.twoFactorEnabled = true;
     await user.save();
 
-    res.status(200).json({ otpauthUrl: secret.otpauth_url });
+    res.status(200).json({
+      otpauthUrl: secret.otpauth_url,
+      secret: secret.base32
+    });
   } catch (error) {
     res.status(500).json({ message: error.message });
   }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const mongoose = require('mongoose');
 const config = require('./config/config');
+const { apiLimiter, authLimiter } = require('./middleware/rateLimiter');
 
 // Routes
 const userRoutes = require('./routes/userRoutes');
@@ -17,6 +18,7 @@ const app = express();
 app.use(cors(config.cors));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+app.use('/api', apiLimiter);
 
 // Routes principales
 app.get('/', (req, res) => {
@@ -25,7 +27,7 @@ app.get('/', (req, res) => {
 
 // Routes d'API
 app.use('/api/users', userRoutes);
-app.use('/api/auth', authRoutes);
+app.use('/api/auth', authLimiter, authRoutes);
 app.use('/api/tasks', taskRoutes);
 app.use('/api/plannings', planningRoutes);
 app.use('/api/chantiers', chantierRoutes);

--- a/backend/src/middleware/rateLimiter.js
+++ b/backend/src/middleware/rateLimiter.js
@@ -1,0 +1,15 @@
+const rateLimit = require('express-rate-limit');
+
+// Limite générale pour les routes API
+const apiLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100
+});
+
+// Limite plus stricte pour l'authentification
+const authLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 10
+});
+
+module.exports = { apiLimiter, authLimiter };

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -58,7 +58,16 @@ const userSchema = new mongoose.Schema({
   emailVerificationExpires: Date,
   // Champs pour la réinitialisation du mot de passe
   resetPasswordToken: String,
-  resetPasswordExpires: Date
+  resetPasswordExpires: Date,
+  // Authentification à deux facteurs
+  twoFactorEnabled: {
+    type: Boolean,
+    default: false
+  },
+  twoFactorSecret: String,
+  // Refresh token
+  refreshTokenHash: String,
+  refreshTokenExpires: Date
 }, {
   timestamps: true
 });

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -7,6 +7,7 @@ const router = express.Router();
 // Routes publiques
 router.post('/register', authController.register);
 router.post('/login', authController.login);
+router.post('/refresh-token', authController.refreshToken);
 router.post('/forgot-password', authController.forgotPassword);
 router.post('/reset-password/:token', authController.resetPassword);
 router.get('/verify-email/:token', authController.verifyEmail);
@@ -16,5 +17,6 @@ router.get('/me', auth, authController.getCurrentUser);
 router.put('/me', auth, authController.updateProfile);
 router.put('/password', auth, authController.changePassword);
 router.post('/resend-verification', auth, authController.resendVerificationEmail);
+router.post('/enable-2fa', auth, authController.enableTwoFactor);
 
 module.exports = router;

--- a/backend/src/utils/encryption.js
+++ b/backend/src/utils/encryption.js
@@ -1,8 +1,9 @@
 const crypto = require('crypto');
+const config = require('../config/config');
 
 const ALGORITHM = 'aes-256-ctr';
 const IV_LENGTH = 16;
-const SECRET = process.env.ENCRYPTION_SECRET || 'entreprise_organiser_encrypt_secret';
+const SECRET = config.encryption.secret;
 
 function encrypt(text) {
   const iv = crypto.randomBytes(IV_LENGTH);

--- a/backend/src/utils/encryption.js
+++ b/backend/src/utils/encryption.js
@@ -1,0 +1,23 @@
+const crypto = require('crypto');
+
+const ALGORITHM = 'aes-256-ctr';
+const IV_LENGTH = 16;
+const SECRET = process.env.ENCRYPTION_SECRET || 'entreprise_organiser_encrypt_secret';
+
+function encrypt(text) {
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, Buffer.from(SECRET, 'utf8').slice(0, 32), iv);
+  const encrypted = Buffer.concat([cipher.update(text, 'utf8'), cipher.final()]);
+  return iv.toString('hex') + ':' + encrypted.toString('hex');
+}
+
+function decrypt(data) {
+  const parts = data.split(':');
+  const iv = Buffer.from(parts.shift(), 'hex');
+  const encryptedText = Buffer.from(parts.join(':'), 'hex');
+  const decipher = crypto.createDecipheriv(ALGORITHM, Buffer.from(SECRET, 'utf8').slice(0, 32), iv);
+  const decrypted = Buffer.concat([decipher.update(encryptedText), decipher.final()]);
+  return decrypted.toString('utf8');
+}
+
+module.exports = { encrypt, decrypt };


### PR DESCRIPTION
## Notes
- Les tests ne se lancent pas car la commande `concurrently` est absente dans l'environnement.

## Summary
- prise en charge des refresh tokens et du 2FA
- création des utilitaires d'encryptage et limiteur de requêtes
- sécurisation des routes /api à l'aide du rate limiter
- ajout du refresh token et des options 2FA dans le modèle utilisateur
- nouvelles routes `refresh-token` et `enable-2fa`

## Testing
- `npm test` *(échoue : concurrently: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e37982c4833282077667f06a7010